### PR TITLE
Enforced LF line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Treat all text files without a CR (as we have Docker)
+* text eol=lf


### PR DESCRIPTION
Fixes #11

Make sure all boxes are checked (add x inside the brackets) when you submit your contribution, remove this sentence before doing so.

- [X] I have thoroughly tested my contribution.

This ensures that the start script has LF-only line endings, even when building on Windows with git configured with system-default CRLF line endings.