### PR TITLE
EMQ Broker timeout period governed by user.

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ These environment variables will ignore for configuration file.
 | ---------------------------| ------------------ | ------------------------- | ------------------------------------- |
 | EMQ_NAME                   | container name     | none                      | emq node short name                   |
 | EMQ_HOST                   | container IP       | none                      | emq node host, IP or FQDN             |
+| EMQ_WAIT_TIME              | 5                  | none                      | wait time in sec before timeout       |
 | EMQ_JOIN_CLUSTER           | none               | none                      | Initial cluster to join               |
 | EMQ_ADMIN_PASSWORD         | public             | none                      | emq admin password                    |
 | PLATFORM_ETC_DIR           | /opt/emqtt/etc     | {{ platform_etc_dir }}    | The etc directory                     |

--- a/start.sh
+++ b/start.sh
@@ -33,6 +33,10 @@ if [[ -z "$EMQ_HOST" ]]; then
     export EMQ_HOST="$LOCAL_IP"
 fi
 
+if [[ -z "$EMQ_WAIT_TIME" ]]; then
+    export EMQ_WAIT_TIME=5
+fi
+
 if [[ -z "$EMQ_NODE__NAME" ]]; then
     export EMQ_NODE__NAME="$EMQ_NAME@$EMQ_HOST"
 fi
@@ -137,7 +141,7 @@ do
     sleep 1
     echo "['$(date -u +"%Y-%m-%dT%H:%M:%SZ")']:waiting emqttd"
     WAIT_TIME=$((WAIT_TIME+1))
-    if [[ $WAIT_TIME -gt 5 ]]; then
+    if [[ $WAIT_TIME -gt $EMQ_WAIT_TIME ]]; then
         echo "['$(date -u +"%Y-%m-%dT%H:%M:%SZ")']:timeout error"
         exit 1
     fi


### PR DESCRIPTION
User should be able to govern the duration after which EMQ broker times out.
In an environment shared across people or orgs, broker (emqttd foreground)
can take variable amount of time to come up. Sometimes this is longer than
5s. Presently it is hard coded to 5 and user is given no option to alter it.

Committer: rejji

Fixes #17, #19 

Make sure all boxes are checked (add x inside the brackets) when you submit your contribution, remove this sentence before doing so.

- [x] I have thoroughly tested my contribution.
- [x] The code changes are reflected in the documentation README.md.
